### PR TITLE
[WO-976] Fix UI when trying to display a message with empty body

### DIFF
--- a/src/tpl/read.html
+++ b/src/tpl/read.html
@@ -50,7 +50,7 @@
   </div><!--/read__working-->
 
   <div class="read__content"
-    ng-show="state.mailList.selected && (!state.mailList.selected.encrypted && (state.mailList.selected.body || state.mailList.selected.html)) || (state.mailList.selected.encrypted && state.mailList.selected.decrypted)">
+    ng-show="(state.mailList.selected && !state.mailList.selected.encrypted) || (state.mailList.selected.encrypted && state.mailList.selected.decrypted)">
     <header class="read__header">
       <div class="read__controls__dummy"></div>
 


### PR DESCRIPTION
did i miss something? why did the ng-show have this clause `(state.mailList.selected.body || state.mailList.selected.html)` ? seems pointless...